### PR TITLE
Prevent spurious lookups

### DIFF
--- a/httpbl/httpbl.py
+++ b/httpbl/httpbl.py
@@ -18,7 +18,7 @@ __email__ = 'gmr@myyearbook.com'
 
 import socket
 
-DNSBL_SUFFIX = 'dnsbl.httpbl.org'
+DNSBL_SUFFIX = 'dnsbl.httpbl.org.'
 
 # Visitor Types
 SEARCH_ENGINE = 0


### PR DESCRIPTION
Hey GMR:

Right now, if httpbl returns NXDOMAIN for a lookup (which it will do for most records, since most IP addresses _aren't_ listed), gethostbyname() will recurse through any "search" domains defined in the resolver config.

This results in at least one extra DNS lookup for every httpbl request that doesn't match a bad guy.  And in the event that the domain has a wildcard defined, you might even get a spurious result.

The simple patch attached here fixes it by appending a trailing period to the hostname.
