### PR TITLE
deal with undocumented search engine indices

### DIFF
--- a/httpbl.py
+++ b/httpbl.py
@@ -125,9 +125,17 @@ class HttpBL(object):
             visitor_types.append(HARVESTER)
         if vt & SUSPICIOUS:
             visitor_types.append(SUSPICIOUS)
+            
+        name = None
+        
+        if not vt:
+            try:
+                name = SEARCH_ENGINES[ts]
+            except IndexError:
+                name = SEARCH_ENGINES[0]
 
         # Return the response dictionary
         return {'days_since_last_activity': days if vt else None,
-                'name': None if vt else SEARCH_ENGINES[ts],
+                'name': name,
                 'threat_score': ts if vt else None,
                 'type': visitor_types if vt else [SEARCH_ENGINE]}

--- a/tests.py
+++ b/tests.py
@@ -56,6 +56,12 @@ class HttpBLTestCase(unittest.TestCase):
                 'name': 'Google',
                 'threat_score': None,
                 'type': [0]
+            },
+            '127.0.29.0': {
+                'days_since_last_activity': None,
+                'name': None,
+                'threat_score': None,
+                'type': [0]
             }
         }
         for ipaddr, expectation in tests.items():


### PR DESCRIPTION
httpbl can return invalid search engine indices.  For example, a lookup of 1.1.1.1 (the cloudflare DNS resolver IP) returns:

127.0.29.0

httpbl will throw an IndexError exception in these cases.  This PR returns Unknown as the search engine type instead.